### PR TITLE
Release `v1.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 
 * [`matteociaroni/flarum-public-suspensions`](https://github.com/matteociaroni/flarum-public-suspensions)
 * [`nearata/flarum-ext-related-discussions`](https://github.com/Nearata/flarum-ext-related-discussions)
+* [`rob006/flarum-ext-last-post-avatar`](https://github.com/rob006-software/flarum-ext-last-post-avatar)
 
 
 **Updated translations for extensions**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 
-1.6.0 (XXXX-XX-XX)
+1.6.0 (2023-02-08)
 ------------------
 
 **Added support for new extensions**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ CHANGELOG
 * [`nearata/flarum-ext-related-discussions`](https://github.com/Nearata/flarum-ext-related-discussions)
 
 
+**Updated translations for extensions**:
+
+* [`justoverclock/theaudiodb-api`](https://extiverse.com/extension/justoverclock/theaudiodb-api)
+
+
 All changes: [v1.5.0...v1.6.0](https://github.com/flarum-lang/chinese-traditional/compare/v1.5.0...v1.6.0).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 **Added support for new extensions**:
 
 * [`matteociaroni/flarum-public-suspensions`](https://github.com/matteociaroni/flarum-public-suspensions)
+* [`nearata/flarum-ext-related-discussions`](https://github.com/Nearata/flarum-ext-related-discussions)
 
 
 All changes: [v1.5.0...v1.6.0](https://github.com/flarum-lang/chinese-traditional/compare/v1.5.0...v1.6.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ CHANGELOG
 
 **Updated translations for extensions**:
 
+* [`club-1/flarum-ext-cross-references`](https://github.com/club-1/flarum-ext-cross-references)
+* [`fof/links`](https://github.com/FriendsOfFlarum/links)
 * [`justoverclock/theaudiodb-api`](https://extiverse.com/extension/justoverclock/theaudiodb-api)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@ CHANGELOG
 =========
 
 
+1.6.0 (XXXX-XX-XX)
+------------------
+
+**Added support for new extensions**:
+
+* [`matteociaroni/flarum-public-suspensions`](https://github.com/matteociaroni/flarum-public-suspensions)
+
+
+All changes: [v1.5.0...v1.6.0](https://github.com/flarum-lang/chinese-traditional/compare/v1.5.0...v1.6.0).
+
+
 1.5.0 (2023-02-01)
 ------------------
 


### PR DESCRIPTION
This is a draft of changelog for the `v1.6.0` release.
Here you can find all related translations changes: [v1.5.0...master](https://github.com/flarum-lang/chinese-traditional/compare/v1.5.0...master).

> ### ⚠️ Do not merge this pull request manually ⚠️
> 
> You should **[approve](https://github.com/rob006-software/flarum-translations/wiki/How-to-approve-release-pull-request)** this pull request instead. After approving, I will automatically update it (release date needs to be adjusted), merge, and tag a new release. You can read more about the process on [forum](https://discuss.flarum.org/d/20807-simplify-translation-process-with-weblate/76).

<details>
<summary>Show release notes preview</summary>

## v1.6.0

<!-- release-notes-begin -->
**Added support for new extensions**:

* [`matteociaroni/flarum-public-suspensions`](https://github.com/matteociaroni/flarum-public-suspensions)
* [`nearata/flarum-ext-related-discussions`](https://github.com/Nearata/flarum-ext-related-discussions)
* [`rob006/flarum-ext-last-post-avatar`](https://github.com/rob006-software/flarum-ext-last-post-avatar)


**Updated translations for extensions**:

* [`club-1/flarum-ext-cross-references`](https://github.com/club-1/flarum-ext-cross-references)
* [`fof/links`](https://github.com/FriendsOfFlarum/links)
* [`justoverclock/theaudiodb-api`](https://extiverse.com/extension/justoverclock/theaudiodb-api)


All changes: [v1.5.0...v1.6.0](https://github.com/flarum-lang/chinese-traditional/compare/v1.5.0...v1.6.0).



<!-- release-notes-end -->

</details>